### PR TITLE
Add `excluding` to `run_for_all_configs_of_type`

### DIFF
--- a/project/algorithms/example_test.py
+++ b/project/algorithms/example_test.py
@@ -1,4 +1,4 @@
-import torch
+import torch.nn
 
 from project.algorithms.testsuites.algorithm_tests import LearningAlgorithmTests
 from project.datamodules.image_classification.image_classification import (

--- a/project/utils/hydra_config_utils.py
+++ b/project/utils/hydra_config_utils.py
@@ -125,7 +125,10 @@ def import_object(target_path: str):
 
 
 def get_all_configs_in_group_of_type(
-    group_name: str, config_target_type: type | tuple[type, ...], include_subclasses: bool = True
+    group_name: str,
+    config_target_type: type | tuple[type, ...],
+    include_subclasses: bool = True,
+    excluding: type | tuple[type, ...] = (),
 ) -> list[str]:
     """Returns the names of all the configs in the given config group that have this target or a
     subclass of it."""
@@ -154,9 +157,24 @@ def get_all_configs_in_group_of_type(
 
         logger.warning(
             RuntimeWarning(
-                f"Unable to tell what kind of object will be created by the target {target} of config {name} in group {group_name}. This config will be skipepd in tests."
+                f"Unable to tell what kind of object will be created by the target {target} of "
+                f"config {name} in group {group_name}. This config will be skipped in tests."
             )
         )
+    config_target_type = (
+        config_target_type if isinstance(config_target_type, tuple) else (config_target_type,)
+    )
+    if excluding is not None:
+        exclude = (excluding,) if isinstance(excluding, type) else excluding
+        names_to_types = {
+            name: object_type
+            for name, object_type in names_to_types.items()
+            if (
+                not issubclass(object_type, exclude)
+                if include_subclasses
+                else object_type not in exclude
+            )
+        }
 
     return [
         name
@@ -165,8 +183,6 @@ def get_all_configs_in_group_of_type(
             issubclass(object_type, config_target_type)
             if include_subclasses
             else object_type in config_target_type
-            if isinstance(config_target_type, tuple)
-            else object_type is config_target_type
         )
     ]
 

--- a/project/utils/testutils.py
+++ b/project/utils/testutils.py
@@ -189,7 +189,9 @@ def run_for_all_vision_datamodules():
     return run_for_all_configs_of_type("datamodule", VisionDataModule)
 
 
-def run_for_all_configs_of_type(config_group: str, config_target_type: type):
+def run_for_all_configs_of_type(
+    config_group: str, config_target_type: type, excluding: type | tuple[type, ...] = ()
+):
     """Parametrizes a test to run with all the configs in the given group that have targets which
     are subclasses of the given type.
 
@@ -201,7 +203,9 @@ def run_for_all_configs_of_type(config_group: str, config_target_type: type):
         ''' This test will run with all the configs in the 'network' group that produce nn.Modules! '''
     ```
     """
-    config_names = get_all_configs_in_group_of_type(config_group, config_target_type)
+    config_names = get_all_configs_in_group_of_type(
+        config_group, config_target_type, include_subclasses=True, excluding=excluding
+    )
     config_name_to_marks = {
         name: default_marks_for_config_name.get(name, []) for name in config_names
     }


### PR DESCRIPTION
Add an `excluding` parameter to `run_for_all_configs_of_type`, which should be helpful to @cmvcordova in his PR #39:

The `example_test.py` module could be changed to exclude the hugging face networks, for example:

```python
# note: replace the `PretrainedModel` below with the base class of all text models in `transformers` (pretrained or not)
@run_for_all_configs_of_type("datamodule", ImageClassificationDataModule)
@run_for_all_configs_of_type("network", torch.nn.Module, excluding=transformers.PretrainedModel) 
class TestExampleAlgo(LearningAlgorithmTests[ExampleAlgorithm]):
    ...
```


Signed-off-by: Fabrice Normandin <normandf@mila.quebec>