### PR TITLE
Fix auto-schema generation for nested config entries with _target_

### DIFF
--- a/project/utils/auto_schema_test/nested.json
+++ b/project/utils/auto_schema_test/nested.json
@@ -70,40 +70,52 @@
       "description": "Whether instantiating this config should recursively instantiate children configs.\nSee: https://hydra.cc/docs/advanced/instantiate_objects/overview/#recursive-instantiation"
     },
     "a": {
+      "type": "object",
+      "additionalProperties": true,
       "properties": {
         "b": {
+          "type": "object",
+          "additionalProperties": true,
           "properties": {
             "foo": {
               "properties": {
                 "_target_": {
-                  "default": "project.utils.auto_schema_test.Foo",
-                  "title": " Target ",
+                  "default": "project.utils.auto_schema_test.Bar",
+                  "title": "Target",
                   "type": "string",
-                  "description": "The _target_ parameter of the Foo."
+                  "description": "Target to instantiate, in this case: `<class 'project.utils.auto_schema_test.Bar'>`\nSee the Hydra docs for '_target_': https://hydra.cc/docs/advanced/instantiate_objects/overview/\n",
+                  "const": "project.utils.auto_schema_test.Bar"
                 },
                 "_recursive_": {
                   "default": false,
                   "title": " Recursive ",
                   "type": "boolean",
-                  "description": "The _recursive_ parameter of the Foo."
+                  "description": "The _recursive_ parameter of the Bar."
                 },
                 "_convert_": {
                   "default": "all",
                   "title": " Convert ",
                   "type": "string",
-                  "description": "The _convert_ parameter of the Foo."
+                  "description": "The _convert_ parameter of the Bar."
                 },
                 "bar": {
                   "title": "Bar",
                   "type": "string",
                   "description": "Description of the `bar` argument."
+                },
+                "baz": {
+                  "title": "Baz",
+                  "type": "integer",
+                  "description": "description of the `baz` argument from the cls docstring instead of the init docstring."
                 }
               },
               "required": [
-                "bar"
+                "bar",
+                "baz"
               ],
-              "title": "Foo",
+              "title": "Bar",
               "type": "object",
+              "description": "Based on the signature of <class 'project.utils.auto_schema_test.Bar'>.\n",
               "additionalProperties": false
             }
           }

--- a/project/utils/auto_schema_test/nested.yaml
+++ b/project/utils/auto_schema_test/nested.yaml
@@ -2,5 +2,6 @@
 a:
   b:
     foo:
-      _target_: project.utils.auto_schema_test.Foo
-      bar: "bob"
+      _target_: project.utils.auto_schema_test.Bar
+      bar: "boo"
+      baz: 123

--- a/project/utils/auto_schema_test/partial.json
+++ b/project/utils/auto_schema_test/partial.json
@@ -1,35 +1,7 @@
 {
+  "title": "Foo",
+  "description": "Based on the signature of <class 'project.utils.auto_schema_test.Foo'>.\n",
   "properties": {
-    "_target_": {
-      "default": "project.utils.auto_schema_test.Foo",
-      "title": "Target",
-      "type": "string",
-      "description": "Target to instantiate, in this case: `project.utils.auto_schema_test.Foo`\nSee the Hydra docs for '_target_': https://hydra.cc/docs/advanced/instantiate_objects/overview/\n",
-      "const": "project.utils.auto_schema_test.Foo"
-    },
-    "_recursive_": {
-      "default": false,
-      "title": "Recursive",
-      "type": "boolean",
-      "description": "Whether instantiating this config should recursively instantiate children configs.\nSee: https://hydra.cc/docs/advanced/instantiate_objects/overview/#recursive-instantiation"
-    },
-    "_convert_": {
-      "default": "all",
-      "title": "Convert",
-      "type": "string",
-      "description": "See https://hydra.cc/docs/advanced/instantiate_objects/overview/#parameter-conversion-strategies",
-      "enum": [
-        "none",
-        "partial",
-        "object",
-        "all"
-      ]
-    },
-    "bar": {
-      "title": "Bar",
-      "type": "string",
-      "description": "Description of the `bar` argument."
-    },
     "defaults": {
       "title": "Hydra defaults",
       "description": "Hydra defaults for this config. See https://hydra.cc/docs/advanced/defaults_list/",
@@ -71,17 +43,42 @@
       },
       "uniqueItems": true
     },
+    "_target_": {
+      "type": "string",
+      "title": "Target",
+      "description": "Target to instantiate, in this case: `<class 'project.utils.auto_schema_test.Foo'>`\nSee the Hydra docs for '_target_': https://hydra.cc/docs/advanced/instantiate_objects/overview/\n",
+      "default": "project.utils.auto_schema_test.Foo",
+      "const": "project.utils.auto_schema_test.Foo"
+    },
+    "_convert_": {
+      "type": "string",
+      "enum": [
+        "none",
+        "partial",
+        "object",
+        "all"
+      ],
+      "title": " Convert ",
+      "description": "The _convert_ parameter of the Foo.",
+      "default": "all"
+    },
     "_partial_": {
       "type": "boolean",
       "title": "Partial",
       "description": "Whether this config calls the target function when instantiated, or creates a `functools.partial` that will call the target.\nSee: https://hydra.cc/docs/advanced/instantiate_objects/overview"
+    },
+    "_recursive_": {
+      "type": "boolean",
+      "title": " Recursive ",
+      "description": "The _recursive_ parameter of the Foo.",
+      "default": false
+    },
+    "bar": {
+      "title": "Bar",
+      "type": "string",
+      "description": "Description of the `bar` argument."
     }
   },
-  "required": [],
-  "title": "Auto-generated schema for partial.yaml",
-  "type": "object",
-  "additionalProperties": false,
-  "description": "Based on the signature of <class 'project.utils.auto_schema_test.Foo'>.",
   "dependentRequired": {
     "_convert_": [
       "_target_"
@@ -95,5 +92,8 @@
     "_recursive_": [
       "_target_"
     ]
-  }
+  },
+  "additionalProperties": false,
+  "required": [],
+  "type": "object"
 }

--- a/project/utils/auto_schema_test/with_defaults.json
+++ b/project/utils/auto_schema_test/with_defaults.json
@@ -1,35 +1,7 @@
 {
+  "title": "Auto-generated schema for with_defaults.yaml",
+  "description": "Schema created by the `auto_schema.py` script.",
   "properties": {
-    "_target_": {
-      "default": "project.utils.auto_schema_test.Foo",
-      "title": "Target",
-      "type": "string",
-      "description": "Target to instantiate.\nSee https://hydra.cc/docs/advanced/instantiate_objects/overview/",
-      "const": "project.utils.auto_schema_test.Foo"
-    },
-    "_recursive_": {
-      "default": false,
-      "title": "Recursive",
-      "type": "boolean",
-      "description": "Whether instantiating this config should recursively instantiate children configs.\nSee: https://hydra.cc/docs/advanced/instantiate_objects/overview/#recursive-instantiation"
-    },
-    "_convert_": {
-      "default": "all",
-      "title": "Convert",
-      "type": "string",
-      "description": "See https://hydra.cc/docs/advanced/instantiate_objects/overview/#parameter-conversion-strategies",
-      "enum": [
-        "none",
-        "partial",
-        "object",
-        "all"
-      ]
-    },
-    "bar": {
-      "title": "Bar",
-      "type": "string",
-      "description": "Description of the `bar` argument."
-    },
     "defaults": {
       "title": "Hydra defaults",
       "description": "Hydra defaults for this config. See https://hydra.cc/docs/advanced/defaults_list/",
@@ -71,18 +43,133 @@
       },
       "uniqueItems": true
     },
+    "_target_": {
+      "type": "string",
+      "title": "Target",
+      "description": "Target to instantiate.\nSee https://hydra.cc/docs/advanced/instantiate_objects/overview/",
+      "default": "project.utils.auto_schema_test.Foo",
+      "const": "project.utils.auto_schema_test.Foo"
+    },
+    "_convert_": {
+      "type": "string",
+      "enum": [
+        "none",
+        "partial",
+        "object",
+        "all"
+      ],
+      "title": "Convert",
+      "description": "See https://hydra.cc/docs/advanced/instantiate_objects/overview/#parameter-conversion-strategies",
+      "default": "all"
+    },
     "_partial_": {
       "type": "boolean",
       "title": "Partial",
       "description": "Whether this config calls the target function when instantiated, or creates a `functools.partial` that will call the target.\nSee: https://hydra.cc/docs/advanced/instantiate_objects/overview"
+    },
+    "_recursive_": {
+      "type": "boolean",
+      "title": "Recursive",
+      "description": "Whether instantiating this config should recursively instantiate children configs.\nSee: https://hydra.cc/docs/advanced/instantiate_objects/overview/#recursive-instantiation",
+      "default": false
+    },
+    "bar": {
+      "title": "Bar",
+      "type": "string",
+      "description": "Description of the `bar` argument."
+    },
+    "hydra": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "launcher": {
+          "properties": {
+            "_target_": {
+              "default": "hydra._internal.core_plugins.basic_launcher.BasicLauncher",
+              "title": "Target",
+              "type": "string",
+              "description": "Target to instantiate, in this case: `<class 'hydra._internal.core_plugins.basic_launcher.BasicLauncher'>`\nSee the Hydra docs for '_target_': https://hydra.cc/docs/advanced/instantiate_objects/overview/\n",
+              "const": "hydra._internal.core_plugins.basic_launcher.BasicLauncher"
+            },
+            "_recursive_": {
+              "default": false,
+              "title": " Recursive ",
+              "type": "boolean",
+              "description": "The _recursive_ parameter of the BasicLauncher."
+            },
+            "_convert_": {
+              "default": "all",
+              "title": " Convert ",
+              "type": "string",
+              "description": "The _convert_ parameter of the BasicLauncher."
+            }
+          },
+          "title": "BasicLauncher",
+          "type": "object",
+          "description": "Based on the signature of <class 'hydra._internal.core_plugins.basic_launcher.BasicLauncher'>.\n",
+          "additionalProperties": false
+        },
+        "sweeper": {
+          "properties": {
+            "_target_": {
+              "default": "hydra._internal.core_plugins.basic_sweeper.BasicSweeper",
+              "title": "Target",
+              "type": "string",
+              "description": "Target to instantiate, in this case: `<class 'hydra._internal.core_plugins.basic_sweeper.BasicSweeper'>`\nSee the Hydra docs for '_target_': https://hydra.cc/docs/advanced/instantiate_objects/overview/\n",
+              "const": "hydra._internal.core_plugins.basic_sweeper.BasicSweeper"
+            },
+            "_recursive_": {
+              "default": false,
+              "title": " Recursive ",
+              "type": "boolean",
+              "description": "The _recursive_ parameter of the BasicSweeper."
+            },
+            "_convert_": {
+              "default": "all",
+              "title": " Convert ",
+              "type": "string",
+              "description": "The _convert_ parameter of the BasicSweeper."
+            },
+            "max_batch_size": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Max Batch Size",
+              "description": "The max_batch_size parameter of the BasicSweeper."
+            },
+            "params": {
+              "anyOf": [
+                {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "title": "Params",
+              "description": "The params parameter of the BasicSweeper."
+            }
+          },
+          "required": [
+            "max_batch_size"
+          ],
+          "title": "BasicSweeper",
+          "type": "object",
+          "description": "Based on the signature of <class 'hydra._internal.core_plugins.basic_sweeper.BasicSweeper'>.\n",
+          "additionalProperties": false
+        }
+      }
     }
   },
-  "required": [
-    "bar"
-  ],
-  "title": "Auto-generated schema for with_defaults.yaml",
-  "type": "object",
-  "description": "Schema created by the `auto_schema.py` script.",
   "dependentRequired": {
     "_convert_": [
       "_target_"
@@ -97,5 +184,9 @@
       "_target_"
     ]
   },
+  "required": [
+    "bar"
+  ],
+  "type": "object",
   "additionalProperties": true
 }

--- a/project/utils/auto_schema_test/with_package_global.json
+++ b/project/utils/auto_schema_test/with_package_global.json
@@ -1,35 +1,7 @@
 {
+  "title": "Foo",
+  "description": "Based on the signature of <class 'project.utils.auto_schema_test.Foo'>.\n",
   "properties": {
-    "_target_": {
-      "default": "project.utils.auto_schema_test.Foo",
-      "title": "Target",
-      "type": "string",
-      "description": "Target to instantiate, in this case: `project.utils.auto_schema_test.Foo`\nSee the Hydra docs for '_target_': https://hydra.cc/docs/advanced/instantiate_objects/overview/\n",
-      "const": "project.utils.auto_schema_test.Foo"
-    },
-    "_recursive_": {
-      "default": false,
-      "title": "Recursive",
-      "type": "boolean",
-      "description": "Whether instantiating this config should recursively instantiate children configs.\nSee: https://hydra.cc/docs/advanced/instantiate_objects/overview/#recursive-instantiation"
-    },
-    "_convert_": {
-      "default": "all",
-      "title": "Convert",
-      "type": "string",
-      "description": "See https://hydra.cc/docs/advanced/instantiate_objects/overview/#parameter-conversion-strategies",
-      "enum": [
-        "none",
-        "partial",
-        "object",
-        "all"
-      ]
-    },
-    "bar": {
-      "title": "Bar",
-      "type": "string",
-      "description": "Description of the `bar` argument."
-    },
     "defaults": {
       "title": "Hydra defaults",
       "description": "Hydra defaults for this config. See https://hydra.cc/docs/advanced/defaults_list/",
@@ -71,19 +43,42 @@
       },
       "uniqueItems": true
     },
+    "_target_": {
+      "type": "string",
+      "title": "Target",
+      "description": "Target to instantiate, in this case: `<class 'project.utils.auto_schema_test.Foo'>`\nSee the Hydra docs for '_target_': https://hydra.cc/docs/advanced/instantiate_objects/overview/\n",
+      "default": "project.utils.auto_schema_test.Foo",
+      "const": "project.utils.auto_schema_test.Foo"
+    },
+    "_convert_": {
+      "type": "string",
+      "enum": [
+        "none",
+        "partial",
+        "object",
+        "all"
+      ],
+      "title": " Convert ",
+      "description": "The _convert_ parameter of the Foo.",
+      "default": "all"
+    },
     "_partial_": {
       "type": "boolean",
       "title": "Partial",
       "description": "Whether this config calls the target function when instantiated, or creates a `functools.partial` that will call the target.\nSee: https://hydra.cc/docs/advanced/instantiate_objects/overview"
+    },
+    "_recursive_": {
+      "type": "boolean",
+      "title": " Recursive ",
+      "description": "The _recursive_ parameter of the Foo.",
+      "default": false
+    },
+    "bar": {
+      "title": "Bar",
+      "type": "string",
+      "description": "Description of the `bar` argument."
     }
   },
-  "required": [
-    "bar"
-  ],
-  "title": "Auto-generated schema for with_package_global.yaml",
-  "type": "object",
-  "additionalProperties": false,
-  "description": "Based on the signature of <class 'project.utils.auto_schema_test.Foo'>.",
   "dependentRequired": {
     "_convert_": [
       "_target_"
@@ -97,5 +92,10 @@
     "_recursive_": [
       "_target_"
     ]
-  }
+  },
+  "additionalProperties": false,
+  "required": [
+    "bar"
+  ],
+  "type": "object"
 }

--- a/project/utils/auto_schema_test/with_target.json
+++ b/project/utils/auto_schema_test/with_target.json
@@ -1,35 +1,7 @@
 {
+  "title": "Foo",
+  "description": "Based on the signature of <class 'project.utils.auto_schema_test.Foo'>.\n",
   "properties": {
-    "_target_": {
-      "default": "project.utils.auto_schema_test.Foo",
-      "title": "Target",
-      "type": "string",
-      "description": "Target to instantiate, in this case: `project.utils.auto_schema_test.Foo`\nSee the Hydra docs for '_target_': https://hydra.cc/docs/advanced/instantiate_objects/overview/\n",
-      "const": "project.utils.auto_schema_test.Foo"
-    },
-    "_recursive_": {
-      "default": false,
-      "title": "Recursive",
-      "type": "boolean",
-      "description": "Whether instantiating this config should recursively instantiate children configs.\nSee: https://hydra.cc/docs/advanced/instantiate_objects/overview/#recursive-instantiation"
-    },
-    "_convert_": {
-      "default": "all",
-      "title": "Convert",
-      "type": "string",
-      "description": "See https://hydra.cc/docs/advanced/instantiate_objects/overview/#parameter-conversion-strategies",
-      "enum": [
-        "none",
-        "partial",
-        "object",
-        "all"
-      ]
-    },
-    "bar": {
-      "title": "Bar",
-      "type": "string",
-      "description": "Description of the `bar` argument."
-    },
     "defaults": {
       "title": "Hydra defaults",
       "description": "Hydra defaults for this config. See https://hydra.cc/docs/advanced/defaults_list/",
@@ -71,19 +43,42 @@
       },
       "uniqueItems": true
     },
+    "_target_": {
+      "type": "string",
+      "title": "Target",
+      "description": "Target to instantiate, in this case: `<class 'project.utils.auto_schema_test.Foo'>`\nSee the Hydra docs for '_target_': https://hydra.cc/docs/advanced/instantiate_objects/overview/\n",
+      "default": "project.utils.auto_schema_test.Foo",
+      "const": "project.utils.auto_schema_test.Foo"
+    },
+    "_convert_": {
+      "type": "string",
+      "enum": [
+        "none",
+        "partial",
+        "object",
+        "all"
+      ],
+      "title": " Convert ",
+      "description": "The _convert_ parameter of the Foo.",
+      "default": "all"
+    },
     "_partial_": {
       "type": "boolean",
       "title": "Partial",
       "description": "Whether this config calls the target function when instantiated, or creates a `functools.partial` that will call the target.\nSee: https://hydra.cc/docs/advanced/instantiate_objects/overview"
+    },
+    "_recursive_": {
+      "type": "boolean",
+      "title": " Recursive ",
+      "description": "The _recursive_ parameter of the Foo.",
+      "default": false
+    },
+    "bar": {
+      "title": "Bar",
+      "type": "string",
+      "description": "Description of the `bar` argument."
     }
   },
-  "required": [
-    "bar"
-  ],
-  "title": "Auto-generated schema for with_target.yaml",
-  "type": "object",
-  "additionalProperties": false,
-  "description": "Based on the signature of <class 'project.utils.auto_schema_test.Foo'>.",
   "dependentRequired": {
     "_convert_": [
       "_target_"
@@ -97,5 +92,10 @@
     "_recursive_": [
       "_target_"
     ]
-  }
+  },
+  "additionalProperties": false,
+  "required": [
+    "bar"
+  ],
+  "type": "object"
 }


### PR DESCRIPTION
The auto-schema generation for nested config entries with a `_target_` was not working correctly. This pull request fixes the issue by properly handling nested entries and generating the schema based on the target signature. Additionally, a description is added to the generated schema to indicate that it is based on the signature of the target.