### PR TITLE
Begin improvement of refs generation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.10"
-      - run: pip install pre-commit
+      - run: pip install 'pre-commit<4.0.0'
       - run: pre-commit --version
       - run: pre-commit install
       - run: pre-commit run --all-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,6 +44,7 @@ repos:
     rev: v1.7.5
     hooks:
       - id: docformatter
+        language: python
         args: [--in-place, --wrap-summaries=99, --wrap-descriptions=99]
         require_serial: true
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ default_language_version:
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       # list of supported hooks: https://pre-commit.com/hooks.html
       - id: trailing-whitespace
@@ -33,7 +33,7 @@ repos:
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
     # Ruff version.
-    rev: "v0.5.7"
+    rev: "v0.6.9"
     hooks:
       - id: ruff
         args: ["--line-length", "99", "--fix"]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -64,6 +64,7 @@ plugins:
   - awesome-pages
   - macros: #https://mkdocs-macros-plugin.readthedocs.io/en/latest/#declaration-of-the-macros-plugin
       module_name: docs/macros
+  - custom_autoref_plugin
   - autorefs
   - gen-files:
       # https://oprypin.github.io/mkdocs-gen-files/#usage

--- a/project/conftest.py
+++ b/project/conftest.py
@@ -123,7 +123,10 @@ def original_datadir(original_datadir: Path):
     """
     relative_portion = original_datadir.relative_to(REPO_ROOTDIR)
     datadir = REPO_ROOTDIR / ".regression_files"
-    if SCRATCH and not datadir.exists():
+
+    use_scratch: bool = False  # todo: enable again later?
+
+    if SCRATCH and not datadir.exists() and use_scratch:
         # puts a symlink .regression_files in the repo root that points to the same dir in $SCRATCH
         actual_dir = SCRATCH / datadir.relative_to(REPO_ROOTDIR)
         actual_dir.mkdir(parents=True, exist_ok=True)

--- a/project/utils/autoref_plugin.py
+++ b/project/utils/autoref_plugin.py
@@ -2,21 +2,14 @@
 considered refs when possible.
 """
 
-# TODOs / plan:
-# - [ ] Replace `this` with [this][] in the markdown file.
-# - Also fix refs like `[lightning.Trainer][]` so that they become
-#      [lightning.Trainer][lightning.pytorch.trainer.trainer.Trainer]
-
 import functools
-
-# from mkdocs_autorefs.references import *
 import re
 
 import lightning
-import torch  # noqa
+import torch
 from mkdocs.config.defaults import MkDocsConfig
 from mkdocs.plugins import (
-    BasePlugin,  # noqa
+    BasePlugin,
     get_plugin_logger,
 )
 from mkdocs.structure.files import Files
@@ -48,10 +41,6 @@ class CustomAutoRefPlugin(BasePlugin):
         def best_display_str(thing) -> str:
             return thing.__module__.split(".")[0] + "." + thing.__qualname__
 
-        def _ref_with_name(thing, name: str) -> str:
-            full_path = thing.__module__ + "." + thing.__qualname__
-            return f"[{name}][{full_path}]"
-
         known_things = [
             lightning.Trainer,
             lightning.LightningModule,
@@ -60,10 +49,6 @@ class CustomAutoRefPlugin(BasePlugin):
         ]
         known_thing_names = [t.__name__ for t in known_things]
         use_translations = True
-
-        # for k, v in translations.items():
-        #     markdown = markdown.replace(k, v)
-        # messes up the refs!
 
         new_markdown = []
         for line_index, line in enumerate(markdown.splitlines(keepends=True)):

--- a/project/utils/autoref_plugin.py
+++ b/project/utils/autoref_plugin.py
@@ -1,0 +1,33 @@
+"""IDEA: Tweak the AutoRefsPlugin so that text in backticks like `this` (more IDE-friendly) are
+considered refs when possible.
+"""
+
+# TODOs / plan:
+# - [ ] Replace `this` with [this][] in the markdown file.
+# - Also fix refs like `[lightning.Trainer][]` so that they become
+#      [lightning.Trainer][lightning.pytorch.trainer.trainer.Trainer]
+
+import re
+from logging import getLogger as get_logger
+
+from mkdocs.config.defaults import MkDocsConfig
+from mkdocs.plugins import BasePlugin  # noqa
+from mkdocs.structure.files import Files
+from mkdocs.structure.pages import Page
+from mkdocs_autorefs.plugin import AutorefsPlugin  # noqa
+
+logger = get_logger(__name__)
+
+
+class CustomAutoRefPlugin(BasePlugin):
+    def on_page_markdown(
+        self, markdown: str, /, *, page: Page, config: MkDocsConfig, files: Files
+    ) -> str | None:
+        # Find all instances where backticks are used and try to convert them to refs.
+
+        # Examples:
+        # - `package.foo.bar` -> [package.foo.bar][]
+        # - `baz` -> [baz][]
+        _modified = re.sub(r"`([^`]+)`", r"[\1][]", markdown)
+
+        return super().on_page_markdown(markdown, page=page, config=config, files=files)

--- a/project/utils/autoref_plugin.py
+++ b/project/utils/autoref_plugin.py
@@ -7,16 +7,26 @@ considered refs when possible.
 # - Also fix refs like `[lightning.Trainer][]` so that they become
 #      [lightning.Trainer][lightning.pytorch.trainer.trainer.Trainer]
 
-import re
-from logging import getLogger as get_logger
+import functools
 
+# from mkdocs_autorefs.references import *
+import re
+
+import lightning
+import torch  # noqa
 from mkdocs.config.defaults import MkDocsConfig
-from mkdocs.plugins import BasePlugin  # noqa
+from mkdocs.plugins import (
+    BasePlugin,  # noqa
+    get_plugin_logger,
+)
 from mkdocs.structure.files import Files
 from mkdocs.structure.pages import Page
 from mkdocs_autorefs.plugin import AutorefsPlugin  # noqa
 
-logger = get_logger(__name__)
+from project.utils.hydra_config_utils import import_object
+
+# Same as in the mkdocs_autorefs plugin.
+logger = get_plugin_logger(__name__)
 
 
 class CustomAutoRefPlugin(BasePlugin):
@@ -28,6 +38,72 @@ class CustomAutoRefPlugin(BasePlugin):
         # Examples:
         # - `package.foo.bar` -> [package.foo.bar][]
         # - `baz` -> [baz][]
-        _modified = re.sub(r"`([^`]+)`", r"[\1][]", markdown)
+        from lightning import Trainer
 
-        return super().on_page_markdown(markdown, page=page, config=config, files=files)
+        thing = Trainer
+
+        def _full_path(thing) -> str:
+            return thing.__module__ + "." + thing.__qualname__
+
+        def best_display_str(thing) -> str:
+            return thing.__module__.split(".")[0] + "." + thing.__qualname__
+
+        def _ref_with_name(thing, name: str) -> str:
+            full_path = thing.__module__ + "." + thing.__qualname__
+            return f"[{name}][{full_path}]"
+
+        known_things = [
+            lightning.Trainer,
+            lightning.LightningModule,
+            lightning.LightningDataModule,
+            torch.nn.Module,
+        ]
+        known_thing_names = [t.__name__ for t in known_things]
+        use_translations = True
+
+        # for k, v in translations.items():
+        #     markdown = markdown.replace(k, v)
+        # messes up the refs!
+
+        new_markdown = []
+        for line_index, line in enumerate(markdown.splitlines(keepends=True)):
+            # Can't convert `this` to `[this][]` in headers, otherwise they break.
+            if line.lstrip().startswith("#"):
+                new_markdown.append(line)
+                continue
+
+            matches = re.findall(r"`([^`]+)`", line)
+
+            for match in matches:
+                thing_name = match
+                if not use_translations:
+                    # Do something dumber
+                    line = line.replace(f"`{thing_name}`", f"[{thing_name}][]")
+                    continue
+                # line = line.replace(f"`{thing_name}`",)
+                if "." not in thing_name and thing_name in known_thing_names:
+                    thing = known_things[known_thing_names.index(thing_name)]
+                else:
+                    thing = _try_import_thing(thing_name)
+
+                if thing is None:
+                    logger.debug(f"Unable to import {thing_name}")
+                    continue
+
+                new_ref = f"[{thing_name}][{_full_path(thing)}]"
+                logger.info(
+                    f"Replacing `{thing_name}` with {new_ref} in {page.file.abs_src_path}:{line_index}"
+                )
+                line = line.replace(f"`{thing_name}`", new_ref)
+
+            new_markdown.append(line)
+
+        return "".join(new_markdown)
+
+
+@functools.cache
+def _try_import_thing(thing: str):
+    try:
+        return import_object(thing)
+    except Exception:
+        return None

--- a/project/utils/autoref_plugin.py
+++ b/project/utils/autoref_plugin.py
@@ -31,15 +31,9 @@ class CustomAutoRefPlugin(BasePlugin):
         # Examples:
         # - `package.foo.bar` -> [package.foo.bar][]
         # - `baz` -> [baz][]
-        from lightning import Trainer
-
-        thing = Trainer
 
         def _full_path(thing) -> str:
             return thing.__module__ + "." + thing.__qualname__
-
-        def best_display_str(thing) -> str:
-            return thing.__module__.split(".")[0] + "." + thing.__qualname__
 
         known_things = [
             lightning.Trainer,
@@ -48,7 +42,7 @@ class CustomAutoRefPlugin(BasePlugin):
             torch.nn.Module,
         ]
         known_thing_names = [t.__name__ for t in known_things]
-        use_translations = True
+        # use_translations = True
 
         new_markdown = []
         for line_index, line in enumerate(markdown.splitlines(keepends=True)):
@@ -61,10 +55,10 @@ class CustomAutoRefPlugin(BasePlugin):
 
             for match in matches:
                 thing_name = match
-                if not use_translations:
-                    # Do something dumber
-                    line = line.replace(f"`{thing_name}`", f"[{thing_name}][]")
-                    continue
+                # if not use_translations:
+                #     # Do something dumber
+                #     line = line.replace(f"`{thing_name}`", f"[{thing_name}][]")
+                #     continue
                 # line = line.replace(f"`{thing_name}`",)
                 if "." not in thing_name and thing_name in known_thing_names:
                     thing = known_things[known_thing_names.index(thing_name)]
@@ -72,7 +66,7 @@ class CustomAutoRefPlugin(BasePlugin):
                     thing = _try_import_thing(thing_name)
 
                 if thing is None:
-                    logger.debug(f"Unable to import {thing_name}")
+                    logger.debug(f"Unable to import {thing_name}, leaving it as-is.")
                     continue
 
                 new_ref = f"[{thing_name}][{_full_path(thing)}]"

--- a/project/utils/autoref_plugin_test.py
+++ b/project/utils/autoref_plugin_test.py
@@ -16,14 +16,22 @@ from .autoref_plugin import CustomAutoRefPlugin
         ),
         ("`torch.Tensor`", "[torch.Tensor][torch.Tensor]"),
         (
-            "a proper full ref: [lightning.Trainer][lightning.pytorch.core.trainer.trainer.Trainer]",
-            "a proper full ref: [lightning.Trainer][lightning.pytorch.core.trainer.trainer.Trainer]",
+            "a proper full ref: "
+            + (
+                _lightning_trainer_ref
+                := "[lightning.Trainer][lightning.pytorch.trainer.trainer.Trainer]"
+            ),
+            # Keep the ref as-is.
+            f"a proper full ref: {_lightning_trainer_ref}",
         ),
         ("`foo.bar`", "`foo.bar`"),
         (
             "`jax.Array`",
+            # not sure if this will make a proper link in mkdocs though.
             "[jax.Array][jax.Array]",
-        ),  # not sure if this will make a proper link in mkdocs though.
+        ),
+        ("`Trainer`", "[Trainer][lightning.pytorch.trainer.trainer.Trainer]"),
+        # since `Trainer` is in the `known_things` list, we add the proper ref.
     ],
 )
 def test_autoref_plugin(input: str, expected: str):

--- a/project/utils/autoref_plugin_test.py
+++ b/project/utils/autoref_plugin_test.py
@@ -1,0 +1,47 @@
+import pytest
+from mkdocs.config.defaults import MkDocsConfig
+from mkdocs.structure.files import File, Files
+from mkdocs.structure.pages import Page
+
+from .autoref_plugin import CustomAutoRefPlugin
+
+
+@pytest.mark.parametrize(
+    ("input", "expected"),
+    [
+        (_header := "## Some header with a ref `lightning.Trainer`", _header),
+        (
+            "a backtick ref: `lightning.Trainer`",
+            "a backtick ref: [lightning.Trainer][lightning.pytorch.trainer.trainer.Trainer]",
+        ),
+        ("`torch.Tensor`", "[torch.Tensor][torch.Tensor]"),
+        (
+            "a proper full ref: [lightning.Trainer][lightning.pytorch.core.trainer.trainer.Trainer]",
+            "a proper full ref: [lightning.Trainer][lightning.pytorch.core.trainer.trainer.Trainer]",
+        ),
+        ("`foo.bar`", "`foo.bar`"),
+        (
+            "`jax.Array`",
+            "[jax.Array][jax.Array]",
+        ),  # not sure if this will make a proper link in mkdocs though.
+    ],
+)
+def test_autoref_plugin(input: str, expected: str):
+    config = MkDocsConfig("mkdocs.yaml")
+    plugin = CustomAutoRefPlugin()
+    result = plugin.on_page_markdown(
+        input,
+        page=Page(
+            title="Test",
+            file=File(
+                "test.md",
+                src_dir="bob",
+                dest_dir="bobo",
+                use_directory_urls=False,
+            ),
+            config=config,
+        ),
+        config=config,
+        files=Files([]),
+    )
+    assert result == expected

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,10 @@ dependencies = [
 readme = "README.md"
 requires-python = ">= 3.10"
 
+[project.entry-points."mkdocs.plugins"]
+custom_autoref_plugin = "project.utils.autoref_plugin:CustomAutoRefPlugin"
+
+
 [project.optional-dependencies]
 docs = [
     "mkdocstrings[python]>=0.25.2",


### PR DESCRIPTION
Idea:
- Tweak the AutoRefsPlugin so that text in backticks like `this` (more IDE-friendly) are converted to refs in the docs when possible.
- Also fix refs like `[lightning.Trainer][]` so that they become [lightning.Trainer][lightning.pytorch.trainer.trainer.Trainer] or whatever is necessary for it to be properly displayed.


Signed-off-by: Fabrice Normandin <normandf@mila.quebec>