### PR TITLE
Improve auto-generation of refs with backticks

### DIFF
--- a/docs/features/jax.md
+++ b/docs/features/jax.md
@@ -10,13 +10,9 @@ There are lots of good reasons why you might want to let Lightning handle the tr
 which are very well described [here](https://lightning.ai/docs/pytorch/stable/).
 
 ??? note "What about end-to-end training in Jax?"
-    This template doesn't include a way to do end-to-end, fully-jitted training in Jax, however, it _might_ be possible to do so in this way:
 
-    - add a new configuration in the `trainer` config group, with a `_target_` pointing to a
-        trainer-like object with a `fit`, `evaluate` and `test` method mimicking those of PyTorch-Lightning.
-    - add a new configuration in the `algorithm` config group pointing to a learning algorithm class that isn't a LightningModule.
+    See the [Jax RL Example (coming soon!)](https://github.com/mila-iqia/ResearchTemplate/pull/55)
 
-    If you want an example of how to do this, please make an issue (or like an existing issue) on GitHub.
 
 ## `JaxExample`: a LightningModule that uses Jax
 

--- a/project/utils/autoref_plugin_test.py
+++ b/project/utils/autoref_plugin_test.py
@@ -12,9 +12,9 @@ from .autoref_plugin import CustomAutoRefPlugin
         (_header := "## Some header with a ref `lightning.Trainer`", _header),
         (
             "a backtick ref: `lightning.Trainer`",
-            "a backtick ref: [lightning.Trainer][lightning.pytorch.trainer.trainer.Trainer]",
+            "a backtick ref: [`lightning.Trainer`][lightning.pytorch.trainer.trainer.Trainer]",
         ),
-        ("`torch.Tensor`", "[torch.Tensor][torch.Tensor]"),
+        ("`torch.Tensor`", "[`torch.Tensor`][torch.Tensor]"),
         (
             "a proper full ref: "
             + (
@@ -28,9 +28,9 @@ from .autoref_plugin import CustomAutoRefPlugin
         (
             "`jax.Array`",
             # not sure if this will make a proper link in mkdocs though.
-            "[jax.Array][jax.Array]",
+            "[`jax.Array`][jax.Array]",
         ),
-        ("`Trainer`", "[Trainer][lightning.pytorch.trainer.trainer.Trainer]"),
+        ("`Trainer`", "[`Trainer`][lightning.pytorch.trainer.trainer.Trainer]"),
         # since `Trainer` is in the `known_things` list, we add the proper ref.
     ],
 )
@@ -78,4 +78,4 @@ def test_ref_using_additional_python_references():
         config=mkdocs_config,
         files=Files([]),
     )
-    assert result == "[ExampleAlgorithm][project.algorithms.example.ExampleAlgorithm]"
+    assert result == "[`ExampleAlgorithm`][project.algorithms.example.ExampleAlgorithm]"

--- a/project/utils/autoref_plugin_test.py
+++ b/project/utils/autoref_plugin_test.py
@@ -35,7 +35,7 @@ from .autoref_plugin import CustomAutoRefPlugin
     ],
 )
 def test_autoref_plugin(input: str, expected: str):
-    config = MkDocsConfig("mkdocs.yaml")
+    config: MkDocsConfig = MkDocsConfig("mkdocs.yaml")  # type: ignore (weird!)
     plugin = CustomAutoRefPlugin()
     result = plugin.on_page_markdown(
         input,
@@ -53,3 +53,29 @@ def test_autoref_plugin(input: str, expected: str):
         files=Files([]),
     )
     assert result == expected
+
+
+def test_ref_using_additional_python_references():
+    mkdocs_config: MkDocsConfig = MkDocsConfig("mkdocs.yaml")  # type: ignore (weird!)
+
+    plugin = CustomAutoRefPlugin()
+
+    page = Page(
+        title="Test",
+        file=File(
+            "test.md",
+            src_dir="bob",
+            dest_dir="bobo",
+            use_directory_urls=False,
+        ),
+        config=mkdocs_config,
+    )
+    page.meta = {"additional_python_references": ["project.algorithms.example"]}
+
+    result = plugin.on_page_markdown(
+        "`ExampleAlgorithm`",
+        page=page,
+        config=mkdocs_config,
+        files=Files([]),
+    )
+    assert result == "[ExampleAlgorithm][project.algorithms.example.ExampleAlgorithm]"

--- a/project/utils/hydra_config_utils.py
+++ b/project/utils/hydra_config_utils.py
@@ -111,8 +111,15 @@ def import_object(target_path: str):
     assert not target_path.endswith(
         ".py"
     ), "expect a valid python path like 'module.submodule.object'"
+    if "." not in target_path:
+        return importlib.import_module(target_path)
 
     parts = target_path.split(".")
+    try:
+        return importlib.import_module(name=parts[-1], package=".".join(parts[:-1]))
+    except (ModuleNotFoundError, AttributeError):
+        pass
+
     for i in range(1, len(parts)):
         module_name = ".".join(parts[:i])
         obj_path = parts[i:]


### PR DESCRIPTION
- Make it possible to specify some packages to include in a yaml-style
  mkdocs header. `backtick` refs in that doc file will then be able to
  reference objects in those modules (or objects in that list)

Signed-off-by: Fabrice Normandin <normandf@mila.quebec>