### PR TITLE
Add timeout to all build steps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,7 @@ jobs:
   linting:
     name: Run linting/pre-commit checks
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
@@ -84,6 +85,7 @@ jobs:
   local_integration_tests:
     needs: [unit_tests, check_docs]
     runs-on: self-hosted
+    timeout-minutes: 20
     strategy:
       max-parallel: 1
       matrix:
@@ -118,6 +120,7 @@ jobs:
   launch-slurm-actions-runner:
     needs: [local_integration_tests]
     runs-on: self-hosted
+    timeout-minutes: 5
     strategy:
       max-parallel: 5
       matrix:
@@ -144,6 +147,7 @@ jobs:
     name: Run integration tests on the ${{ matrix.cluster }} cluster in job ${{ needs.launch-slurm-actions-runner.outputs.job_id}}
     needs: [launch-slurm-actions-runner]
     runs-on: ${{ matrix.cluster }}
+    timeout-minutes: 20
     strategy:
       max-parallel: 5
       matrix:
@@ -178,6 +182,7 @@ jobs:
     needs: [local_integration_tests, slurm_integration_tests]
     runs-on: ubuntu-latest
     name: Upload coverage reports to Codecov
+    timeout-minutes: 5
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
- Trying to figure out what caused the self-hosted GitHub runner to
  timeout recently. Perhaps adding a timeout value will help in case a
  test accidentally tries to do multiprocessing and hangs, or
  something similar? (has happened before)

Signed-off-by: Fabrice Normandin <normandf@mila.quebec>