### PR TITLE
Fixed MeasureSamplesPerSecondCallback and changed configs

### DIFF
--- a/project/algorithms/callbacks/samples_per_second.py
+++ b/project/algorithms/callbacks/samples_per_second.py
@@ -190,7 +190,7 @@ class MeasureSamplesPerSecondCallback(lightning.Callback, Generic[BatchType]):
             return next(
                 v.shape[0]
                 for v in optree.tree_leaves(batch)  # type: ignore
-                if isinstance(v, torch.Tensor) and v.ndim > 1
+                if isinstance(v, torch.Tensor) and v.ndim >= 1
             )
         raise NotImplementedError(
             f"Don't know how many 'samples' there are in batch of type {type(batch)}"

--- a/project/configs/trainer/logger/wandb.yaml
+++ b/project/configs/trainer/logger/wandb.yaml
@@ -2,6 +2,7 @@
 
 wandb:
   _target_: lightning.pytorch.loggers.wandb.WandbLogger
+  entity: "MyOrganisation" #Optionnal
   project: "ResearchTemplate"
   name: ${name}
   save_dir: "."

--- a/project/configs/trainer/logger/wandb.yaml
+++ b/project/configs/trainer/logger/wandb.yaml
@@ -2,7 +2,7 @@
 
 wandb:
   _target_: lightning.pytorch.loggers.wandb.WandbLogger
-  entity: "MyOrganisation" #Optionnal
+  entity: null  # Optional. It can be useful to set this explicitly if you use a different organization account for this project.
   project: "ResearchTemplate"
   name: ${name}
   save_dir: "."

--- a/project/configs/trainer/logger/wandb_cluster.yaml
+++ b/project/configs/trainer/logger/wandb_cluster.yaml
@@ -1,7 +1,7 @@
 defaults:
   - wandb
 wandb:
-  entity: "MyOrganisation" #Optionnal
+  entity: null  # Optional. It can be useful to set this explicitly if you use a different organization account for this project.
   project: "ResearchTemplate"
   # TODO: Use the Orion trial name?
   name: ${oc.env:SLURM_JOB_ID}_${oc.env:SLURM_PROCID}


### PR DESCRIPTION
Hello everyone, 

Here's a small Pull Request that features 2 small modifications:

- I fixed the function `get_num_samples` of the callback `MeasureSamplesPerSecondCallback` that used to raise an error when working with batch as `dict` object when value referred to scalar, which can happen for instance when doing boolean regression or if target is, for some reasons, not one-hot encoded. 
- I added an entity attribute to be able to log into project that are own by a Wandb organisation (e.g. Mila).